### PR TITLE
Merge numerous commits for a cleaner git history

### DIFF
--- a/master-job/Jenkinsfile
+++ b/master-job/Jenkinsfile
@@ -1,0 +1,45 @@
+podTemplate(
+  cloud: 'openshift',
+  name: 'ccp-pipeline',
+  label: 'ccp-pipeline',
+  serviceAccount: 'jenkins',
+  containers: [
+    containerTemplate(
+      name: 'jnlp',
+      image: 'registry.centos.org/dharmit/ccp-openshift-slave',
+      ttyEnabled: true,
+      alwaysPullImage: true,
+      workingDir: '/tmp',
+      privileged: true,
+      args: '${computer.jnlpmac} ${computer.name}'
+    )
+  ],
+  volumes: [
+    hostPathVolume(
+      hostPath: '/var/run/docker.sock',
+      mountPath: '/var/run/docker.sock'
+    )
+  ]
+)
+{
+  node('ccp-pipeline') {
+    stage('Checkout Source') {
+      dir("${PIPELINE_NAME}"){
+        git url: '${GIT_URL}', branch: '${GIT_BRANCH}'
+      }
+    }
+    stage('Build Docker image') {
+      dir("${PIPELINE_NAME}/${GIT_PATH}"){
+        sh "docker build -t ${APP_ID}/${JOB_ID}:${DESIRED_TAG} -f ${TARGET_FILE} ."
+        sh "docker images"
+      }
+    }
+    stage('Push image to registry') {
+      sh '''
+      docker login -u openshift -p `oc whoami -t` 172.30.1.1:5000 &&
+      docker tag ${APP_ID}/${JOB_ID}:${DESIRED_TAG} 172.30.1.1:5000/${APP_ID}/${JOB_ID}:${DESIRED_TAG} &&
+      docker push 172.30.1.1:5000/${APP_ID}/${JOB_ID}:${DESIRED_TAG}
+      '''
+    }
+  }
+}

--- a/master-job/template.yaml
+++ b/master-job/template.yaml
@@ -1,0 +1,86 @@
+apiVersion: "v1"
+kind: "Template"
+metadata:
+  name: "master-job-template"
+objects:
+  - apiVersion: "v1"
+    kind: "BuildConfig"
+    metadata:
+      name: ${PIPELINE_NAME}
+    spec:
+      source:
+        type: Git
+        git:
+          uri: ${JENKINSFILE_GIT_URL}
+          ref: ${JENKINSFILE_GIT_BRANCH}
+        contextDir: ${CONTEXT_DIR}
+      strategy:
+        type: "JenkinsPipeline"
+        jenkinsPipelineStrategy: 
+          jenkinsfilePath: "Jenkinsfile"
+          env:
+          - name: GIT_URL
+            value: ${GIT_URL}
+          - name: GIT_PATH
+            value: ${GIT_PATH}
+          - name: TARGET_FILE
+            value: ${TARGET_FILE}
+          - name: DESIRED_TAG
+            value: ${DESIRED_TAG}
+          - name: NOTIFY_EMAIL
+            value: ${NOTIFY_EMAIL}
+          - name: DEPENDS_ON
+            value: ${DEPENDS_ON}
+          - name: BUILD_CONTEXT
+            value: ${BUILD_CONTEXT}
+parameters:
+- description: "Path to a directory containing a Dockerfile"
+  displayName: "Git Path"
+  name: GIT_PATH
+  required: true
+- description: "Name of the dockerfile to be built"
+  displayName: Dockerfile
+  name: TARGET_FILE
+  required: true
+  value: "/"
+- description: Tag for the resulting image
+  displayName: Desired Tag
+  name: DESIRED_TAG
+  required: true
+- description: Email to send notification to
+  displayName: Notification email
+  name: NOTIFY_EMAIL
+  required: true
+- description: Parent image for the project
+  displayName: Parent image
+  name: DEPENDS_ON
+- description: URL to the Git Repo
+  displayName: Git URL
+  name: GIT_URL
+- description: Git branch to build off
+  displayName: Git Branch
+  name: GIT_BRANCH
+  required: true
+- description: Docker build context
+  displayName: Build Context
+  name: BUILD_CONTEXT
+  required: true
+  value: "./"
+- description: Name of the Pipeline as we want to show up on OpenShift console
+  displayName: Pipeline Name
+  name: PIPELINE_NAME
+  required: true
+- description: Git repo containing the Jenkinsfile
+  displayName: Jenkinsfile repo
+  name: JENKINSFILE_GIT_URL
+  required: true
+  value: https://github.com/dharmit/ccp-openshift
+- description: Git repo branch containing the Jenkinsfile
+  displayName: Jenkinsfile repo branch
+  name: JENKINSFILE_GIT_BRANCH
+  required: true
+  value: master-job
+- description: Context dir is base path to find Jenkinsfile
+  displayName: Context dir
+  name: CONTEXT_DIR
+  required: true

--- a/seed-job/Jenkinsfile
+++ b/seed-job/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+  agent {
+    kubernetes {
+        label 'seed-slave'
+        cloud 'openshift'
+        serviceAccount 'jenkins'
+        containerTemplate {
+          name 'jnlp'
+          image "registry.centos.org/dharmit/ccp-openshift-slave"
+          alwaysPullImage true
+          workingDir '/tmp'
+          args '${computer.jnlpmac} ${computer.name}'
+          ttyEnabled false
+       }
+    }
+  }
+  stages {
+    stage('Checkout SCM') {
+      steps {
+        checkout scm
+      }
+    }
+    stage('Checkout sources') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: [[name: "${CONTAINER_INDEX_BRANCH}"]],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'RelativeTargetDirectory', relativeTargetDir: "${PIPELINE_TARGET_DIR}"]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: [
+            [url: "${CONTAINER_INDEX_LOCATION}"]
+          ]
+        ])
+         }
+    }
+        stage('Parse index') {
+      steps {
+          sh "python seed-job/parser.py"
+          sh "cat projects.sh"
+          sh "sh projects.sh"
+      }
+    }
+  }
+}

--- a/seed-job/buildconfig.yaml
+++ b/seed-job/buildconfig.yaml
@@ -1,0 +1,24 @@
+kind: "BuildConfig"
+apiVersion: "v1"
+metadata:
+  name: "container-index-seed-pipeline"
+spec:
+  source:
+    type: Git
+    git:
+      uri: "https://github.com/dharmit/ccp-openshift"
+      ref: "master-job"
+    contextDir: "seed-job"
+  strategy:
+    type: "JenkinsPipeline"
+    jenkinsPipelineStrategy:
+      jenkinsfilePath: "Jenkinsfile"
+      env:
+      - name: CONTAINER_INDEX_LOCATION
+        value: https://github.com/dharmit/ccp-openshift-index
+      - name: CONTAINER_INDEX_BRANCH
+        value: master
+      - name: PIPELINE_TARGET_DIR
+        value: "source"
+  triggers:
+      - type: ConfigChange

--- a/seed-job/parser.py
+++ b/seed-job/parser.py
@@ -1,0 +1,32 @@
+import yaml
+
+with open("source/projects.yaml") as stream:
+    try:
+        yml_dict = (yaml.load(stream))
+    except yaml.YAMLError as exc:
+        print (exc)
+
+oc_apply = "| oc apply -f -"
+
+for entry in yml_dict["Projects"]:
+    pipeline_name = entry["app-id"] + "-" + entry["job-id"] + "-" + \
+        entry["desired-tag"]
+    command = "oc process -f seed-job/template.yaml " + \
+        "-p GIT_URL={} ".format(entry["git-url"]) + \
+        "-p GIT_PATH={} ".format(entry["git-path"]) + \
+        "-p GIT_BRANCH={} ".format(entry["git-branch"]) + \
+        "-p DESIRED_TAG={} ".format(entry["desired-tag"]) + \
+        "-p NOTIFY_EMAIL={} ".format(entry["notify-email"]) + \
+        "-p PIPELINE_NAME={} ".format(pipeline_name) + \
+        "-p DEPENDS_ON={} ".format(entry["depends-on"]) + \
+        "-p TARGET_FILE={} ".format(entry["target-file"]) + \
+        "-p CONTEXT_DIR={} ".format("master-job") + \
+        "-p APP_ID={} ".format(entry["app-id"]) + \
+        "-p JOB_ID={} ".format(entry["job-id"])
+
+    # there's gotta be a better way to ensure that buildconfigs created by
+    # parsing the yaml file get triggered automatically for first run.
+    oc_build = "oc start-build {} -n myproject".format(pipeline_name)
+
+    with open("projects.sh", "a+") as f:
+        f.write("{} {} && {} \n".format(command, oc_apply, oc_build))

--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -1,0 +1,102 @@
+apiVersion: "v1"
+kind: "Template"
+metadata:
+  name: "master-job-template"
+objects:
+  - apiVersion: "v1"
+    kind: "BuildConfig"
+    metadata:
+      name: ${PIPELINE_NAME}
+    spec:
+      source:
+        type: Git
+        git:
+          uri: ${JENKINSFILE_GIT_URL}
+          ref: ${JENKINSFILE_GIT_BRANCH}
+        contextDir: ${CONTEXT_DIR}
+      strategy:
+        type: "JenkinsPipeline"
+        jenkinsPipelineStrategy: 
+          jenkinsfilePath: "Jenkinsfile"
+          env:
+          - name: GIT_URL
+            value: ${GIT_URL}
+          - name: GIT_BRANCH
+            value: ${GIT_BRANCH}
+          - name: GIT_PATH
+            value: ${GIT_PATH}
+          - name: TARGET_FILE
+            value: ${TARGET_FILE}
+          - name: DESIRED_TAG
+            value: ${DESIRED_TAG}
+          - name: NOTIFY_EMAIL
+            value: ${NOTIFY_EMAIL}
+          - name: DEPENDS_ON
+            value: ${DEPENDS_ON}
+          - name: BUILD_CONTEXT
+            value: ${BUILD_CONTEXT}
+          - name: PIPELINE_NAME
+            value: ${PIPELINE_NAME}
+          - name: APP_ID
+            value: ${APP_ID}
+          - name: JOB_ID
+            value: ${JOB_ID}
+parameters:
+- description: "Path to a directory containing a Dockerfile"
+  displayName: "Git Path"
+  name: GIT_PATH
+  required: true
+- description: "Name of the dockerfile to be built"
+  displayName: Dockerfile
+  name: TARGET_FILE
+  required: true
+- description: Tag for the resulting image
+  displayName: Desired Tag
+  name: DESIRED_TAG
+  required: true
+- description: Email to send notification to
+  displayName: Notification email
+  name: NOTIFY_EMAIL
+  required: true
+- description: Parent image for the project
+  displayName: Parent image
+  name: DEPENDS_ON
+- description: URL to the Git Repo
+  displayName: Git URL
+  name: GIT_URL
+- description: Git branch to build off
+  displayName: Git Branch
+  name: GIT_BRANCH
+  required: true
+- description: Docker build context
+  displayName: Build Context
+  name: BUILD_CONTEXT
+  required: true
+  value: "./"
+- description: Name of the Pipeline as we want to show up on OpenShift console
+  displayName: Pipeline Name
+  name: PIPELINE_NAME
+  required: true
+- description: Git repo containing the Jenkinsfile
+  displayName: Jenkinsfile repo
+  name: JENKINSFILE_GIT_URL
+  required: true
+  value: https://github.com/dharmit/ccp-openshift
+- description: Git repo branch containing the Jenkinsfile
+  displayName: Jenkinsfile repo branch
+  name: JENKINSFILE_GIT_BRANCH
+  required: true
+  value: master-job
+- description: Context dir is base path to find Jenkinsfile
+  displayName: Context dir
+  name: CONTEXT_DIR
+  required: true
+- description: app_id is analogoues to username in Docker Hub
+  displayName: App ID
+  name: APP_ID
+  required: true
+- description: job_id is analogoues to repo name in Docker Hub
+  displayName: Job ID
+  name: JOB_ID
+  required: true
+


### PR DESCRIPTION
Add projects to be built

Add BuildConfig for seed job

Added ref for the seed-job buildconfig

Jenkinsfile for parsing stage

Use Jenkinsfile created by Andy

Use buildconfig created by Andy

Correct indentation and add trigger to build config

Add quotes in Jeninsfile

Add agent info to use custom slave

Have more relevant label for slave pods

Moved projects to separate repo

Modify Jenkinsfile to use different slave image

Add parser to parse index entries

Modify stage name and remove debug statement

Template for build config to trigger more jobs

Add parameters to the template

Git URI and GIT_URL are two different pieces

Add jenkinsfilePath

Make parser parse the index and do oc process

Make template available in same dir as parser

Change ref for buildconfig

Underscore to hyphen

Check the oc project info

Add debug shell commands to Jenkinsfile

Correct path to the template

More debug statement, yay

Fix python string concatenation mistkes

GIT_PATH was missing

Use PIPE

Do oc process in Jenkinsfile

Separate oc apply from parser file

Evaluates depends-on

Evaluate target file from index entry

Jenkinsfile for master job

Add the missing GIT_BRANCH in BuildConfig

Checkout SCM stage

 Trigger build as soon as buildconfig is created from template

Make pod privileged and mount docker socket

Check if docker command works

Change volumes to go to containerTemplate

Debug statements for Docker

Create a podTemplate instead of containerTemplate

Use scripted pipeline for podTemplate

Use simpler way to checkout git repo

Add pipeline-name to job parameters

Build images

Add more parameters to the job

A small thing like missing space can cause failures

Add stage for Dockerfile lint

Don't use cache when building images

Remove dockerfile lint stage for time being

Add atomic scan stage

Change the atomic scanner image

Don't scan images for time being

Add stage to push image to internal registry

Login as openshift and use DNS for registry

Use service IP instead of DNS

Make one shell command out of three