### PR TITLE
Triggers job upon config change

### DIFF
--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -170,6 +170,8 @@ objects:
             value: ${PRE_BUILD_CONTEXT}
           - name: REGISTRY_URL
             value: ${REGISTRY_URL}
+      triggers:
+          - type: ConfigChange
 parameters:
 - description: "Path to a directory containing a Dockerfile"
   displayName: "Git Path"


### PR DESCRIPTION
We were under an impression that pipelines were configured to be triggered upon config change. However that wasn't the case. This PR adds that. But it can be fully tested only when we substantially modify `parser.py` to not trigger every pipeline build on every run and trigger only the new builds. 