### PR TITLE
Changing default container index

### DIFF
--- a/seed-job/buildtemplate.yaml
+++ b/seed-job/buildtemplate.yaml
@@ -82,7 +82,7 @@ parameters:
   displayName: Container Index
   name: CONTAINER_INDEX_REPO
   required: true
-  value: https://github.com/navidshaikh/ccp-openshift-index
+  value: https://github.com/dharmit/ccp-openshift-index
 - description: "Container Index branch to use"
   displayName: Container Index branch
   name: CONTAINER_INDEX_BRANCH


### PR DESCRIPTION
Doing this because the index
https://github.com/navidshaikh/ccp-openshift-index came in as a part of
PR #21 which used this index for testing purpose, I guess. Also, it has
only two projects. We need more projects even in a temporary index

ping @bamachrn 