### PR TITLE
Removes leftover returnStatus: true param in scan execution stage

### DIFF
--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -108,7 +108,7 @@ objects:
                                   sh "cat rpm-verify"
                                 },
                                 "Miscellaneous updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1", returnStatus: true)
+                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
                                   sh "cat misc-updates"
                                 },
                                 "Container capabilities": {


### PR DESCRIPTION
  Even if a single scanner fails to execute, the pipeline should fail.
  This is ensured by not adding `returnStatus: true` in scan stage
  execution command. There was a left over param, removing it in this
  patchset.