### PR TITLE
Updating templates to explicitly mention stages for parallel.

### DIFF
--- a/seed-job/template.yaml
+++ b/seed-job/template.yaml
@@ -100,21 +100,29 @@ objects:
                         stage('Scan the image') {
                             parallel (
                                 "RPM updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/yumupdates.py > yum-check-update 2>&1")
-                                  sh "cat yum-check-update"
+                                  stage('Scan: RPM updates') {
+                                    sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/yumupdates.py > yum-check-update 2>&1")
+                                    sh "cat yum-check-update"
+                                  }
                                 },
                                 "Verify RPMs": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/rpmverify.py > rpm-verify 2>&1")
-                                  sh "cat rpm-verify"
+                                  stage('Scan: Verify RPMs') {
+                                    sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/rpmverify.py > rpm-verify 2>&1")
+                                    sh "cat rpm-verify"
+                                  }
                                 },
                                 "Miscellaneous updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
-                                  sh "cat misc-updates"
+                                  stage('Scan: Miscellaneous updates') {
+                                    sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
+                                    sh "cat misc-updates"
+                                  }
                                 },
                                 "Container capabilities": {
-                                  def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
-                                  sh "cat capabilities"
+                                  stage('Scan: Container capabilities') {
+                                    def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
+                                    sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
+                                    sh "cat capabilities"
+                                  }
                                 }
                             )
                         }

--- a/weekly-scan/template.yaml
+++ b/weekly-scan/template.yaml
@@ -59,21 +59,29 @@ objects:
                         stage('Scan the image') {
                             parallel (
                                 "RPM updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/yumupdates.py > yum-check-update 2>&1")
-                                  sh "cat yum-check-update"
+                                  stage('Scan: RPM updates') {
+                                    sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/yumupdates.py > yum-check-update 2>&1")
+                                    sh "cat yum-check-update"
+                                  }
                                 },
                                 "Verify RPMs": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/rpmverify.py > rpm-verify 2>&1")
-                                  sh "cat rpm-verify"
+                                  stage('Scan: Verify RPMs') {
+                                    sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/rpmverify.py > rpm-verify 2>&1")
+                                    sh "cat rpm-verify"
+                                  }
                                 },
                                 "Miscellaneous updates": {
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
-                                  sh "cat misc-updates"
+                                  stage('Scan: Miscellaneous updates') {
+                                    sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/misc_package_updates.py all > misc-updates 2>&1")
+                                    sh "cat misc-updates"
+                                  }
                                 },
                                 "Container capabilities": {
-                                  def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
-                                  sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
-                                  sh "cat capabilities"
+                                  stage('Scan: Container capabilities') {
+                                    def run_label = sh (script: "docker inspect ${image_name} --format '{{ index .Config.Labels \"RUN\" }}'")
+                                    sh (returnStdout: true, script: "docker run --rm --volumes-from `docker ps -qf name=${daemonset_name}` --entrypoint /bin/python ${image_name} /opt/scanning/container-capabilities.py ' ${run_label} ' > capabilities 2>&1")
+                                    sh "cat capabilities"
+                                  }
                                 }
                             )
                         }


### PR DESCRIPTION
The explicit naming gives us option to correctly filter
data via the workflow API.
As a side affect, this helps align the templates to
recommended approach

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>